### PR TITLE
fix: Add string type to template literal expression

### DIFF
--- a/config/head.ts
+++ b/config/head.ts
@@ -4,7 +4,7 @@ const description =
   'Easily find the perfect API for you and your project. Navigate through hundreds of categorized lists to spice up your project!'
 
 const headConfig: NuxtOptionsHead = {
-  titleTemplate: (chunk) =>
+  titleTemplate: (chunk: string) =>
     chunk ? `${chunk} - API Party` : 'API Party | Awesome collection of APIs',
   // Meta tags for SEO
   meta: [


### PR DESCRIPTION
Resolves deepsource issue identified in: https://deepsource.io/gh/TheLearneer/api-party/issue/JS-0378/occurrences/